### PR TITLE
 Fix #5 by using #EXTINF duration information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+*.mp4
+/concat

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func printDebug(msg ...interface{})  {
+	if debug {
+		fmt.Println(msg...)
+	}
+}
+
+func printDebugf(format string, args ...interface{})  {
+	if debug {
+		fmt.Printf(format, args...)
+	}
+}
+
+func printFatal(err error, msg ...interface{})  {
+	if len(msg) > 0 {
+		fmt.Println(msg...)
+	}
+	printDebug(err)
+	os.Exit(1)
+}
+
+func printFatalf(err error, format string, args ...interface{})  {
+	if len(format) > 0 {
+		fmt.Printf(format, args...)
+	}
+	printDebug(err)
+	os.Exit(1)
+}

--- a/main.go
+++ b/main.go
@@ -132,6 +132,8 @@ func startingChunk(sh int, sm int, ss int, target int) int {
 }
 
 func downloadChunk(newpath string, edgecastBaseURL string, chunkNum string, chunkName string, vodID string, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	sem.Acquire()
 
 	if debug {
@@ -152,7 +154,6 @@ func downloadChunk(newpath string, edgecastBaseURL string, chunkNum string, chun
 
 	_ = ioutil.WriteFile(newpath + "/" + vodID+"_"+chunkNum+chunkFileExtension, body, 0644)
 
-	defer wg.Done()
 	sem.Release()
 }
 


### PR DESCRIPTION
This PR addresses the following issues:
- Fix https://github.com/ArneVogel/concat/issues/5
    - I don't know if there are cases where the #EXTINF metadata is not available, therefore the previous solution is still used as a fallback.
- Make clip boundaries more accurate
- Retry failed downloads two times