### PR TITLE
Mention deploy-to-heroku version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Calling options:
 + -quality `-start="720p60"` if you don't set the quality concat will try to download the vod in the highest available quality, see -qualityinfo for all available quality options for each vod
 + -qualityinfo `-qualityinfo`
 
+## Deploy to Heroku version
+https://github.com/gyfis/concat-web
 
 ## More info
 [Blog post](https://www.arnevogel.com/standalone-concat-version/) about the tool.


### PR DESCRIPTION
It would probably make more sense to merge the project into this repo so that the concat lib is always up-to-date.