### PR TITLE
Variable semaphore number

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Calling options:
 + -end `-end="1 20 30"`
 + -quality `-quality="720p60"` if you don't set the quality concat will try to download the vod in the highest available quality, see -qualityinfo for all available quality options for each vod
 + -qualityinfo `-qualityinfo`
++ -max-concurrent-downloads `-max-concurrent-downloads 5` change the number of chunks that concat will attempt to download simultaneously
 
 ## Deploy to Heroku version
 https://github.com/gyfis/concat-web

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var ffmpegCMD string = `ffmpeg`
 var debug bool
 var twitch_client_id string = "aokchnui2n8q38g0vezl9hq6htzy4c"
 
-var sem = semaphore.New(5)
+var sem *semaphore.Semaphore
 
 /*
 	Returns the signature and token from a tokenAPILink
@@ -593,12 +593,13 @@ func main() {
 	end := flag.String("end", standardStartAndEnd, "For example: 1 20 0 for ending the vod at 1 hour and 20 minutes")
 	quality := flag.String("quality", sourceQuality, "chunked for source quality is automatically used if -quality isn't set")
 	debugFlag := flag.Bool("debug", false, "debug output")
-
+	semaphoreLimit := flag.Int("max-concurrent-downloads", 5, "change maximum number of concurrent downloads")
+	
 	flag.Parse()
 
 	debug = *debugFlag;
-	
-	
+	sem = semaphore.New(*semaphoreLimit)
+
 	if !rightVersion() {
 		fmt.Printf("\nYou are using an old version of concat. Check out %s for the most recent version.\n\n",currentReleaseLink)
 	}


### PR DESCRIPTION
When I tried to use concat I experienced a lot of time outs which made it impossible for me to finish any videos. The root cause of this seems to be my own poor internet connection, so limiting the number of semaphores really helped with it. I thought it would be nice to make it a customizable feature in case anyone else that stumbles across the program had the same problem.