### PR TITLE
Consistent capitalization of OS names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # concat
 ## Download
-Go to [releases](https://github.com/ArneVogel/concat/releases) for the current build. Download concat.exe if you are on windows and concat if want to use it on ubuntu.
+Go to [releases](https://github.com/ArneVogel/concat/releases) for the current build. Download concat.exe if you are on Windows and concat if want to use it on Ubuntu.
 
 ## Prerequisite
-You need ffmpeg for this tool to work. On windows you can get it [here](https://www.ffmpeg.org/download.html). 
+You need ffmpeg for this tool to work. On Windows you can get it [here](https://www.ffmpeg.org/download.html). 
 On Ubuntu "sudo apt-get install ffmpeg" will work.
 
 ## Usage


### PR DESCRIPTION
While looking at the readme I saw that the capitalization of OS names was mixed (for example "Ubuntu" and "ubuntu") so I changed them both to "Ubuntu". I also changed both instances of "windows" to "Windows" since that's the more official name for the system and to keep it consistent with "Ubuntu". 