### PR TITLE
Fix last VOD quality setting not being recognized

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func accessUsherAPI(usherAPILink string) (map[string]string, error) {
 
 	printDebugf("\nUsher API response:\n%s\n", respString)
 
-	var re = regexp.MustCompile(qualityStart + "([^\"]+)" + qualityEnd + "\n([^\n]+)\n")
+	var re = regexp.MustCompile(qualityStart + "([^\"]+)" + qualityEnd + "\n([^\n]+)")
 	match := re.FindAllStringSubmatch(respString, -1)
 
 	edgecastURLmap := make(map[string]string)


### PR DESCRIPTION
There is an issue where the last VOD quality in the Usher API response is not detected and cannot be downloaded.

In `func accessUsherAPI`, the response from the Usher API `respString` contains a bunch of quality entries in the format of

> 
> ...
> #EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="1080p60",NAME="1080p60",AUTOSELECT=YES,DEFAULT=YES
> #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=5265424,CODECS="avc1.4D4028,mp4a.40.2",RESOLUTION=1920x1080,VIDEO="1080p60"
> http://d2nvs31859zcd8.cloudfront.net/twitch/.../index-dvr.m3u8
> ...


The regex currently used to match each entry is `VIDEO="([^\"]+)"\n([^\n]+)\n`. The problem is that the last quality entry will not get matched, because the response ends without a newline character. I therefore propose removing the last newline character requirement, that is, changing the regex to `VIDEO="([^\"]+)"\n([^\n]+)`. This will ensure that the last quality entry will also be matched. Also it should not break other matches, since the last part of the regex `([^\n]+)` will stop matching once it encounters a newline anyway.

This is likely the cause of issue #53 where VODs with only one quality setting cannot be downloaded at all.